### PR TITLE
Expand build matrix and optimize pipeline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,6 @@ indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{md,yml}]
+[*.{md,yml,json}]
 indent_size = 2
 indent_style = space

--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -1,55 +1,83 @@
 [
   {
-    "nginx-version": "1.30",
+    "nginx-version": "1.24",
     "build-mode": "--add-module",
+    "ffmpeg-version": "distro",
     "ubuntu-version": "24.04",
     "arch": "amd64"
   },
   {
-    "nginx-version": "1.31",
+    "nginx-version": "1.24",
     "build-mode": "--add-dynamic-module",
-    "ubuntu-version": "26.04",
-    "arch": "arm64"
-  },
-  {
-    "nginx-version": "1.31",
-    "ffmpeg-version": "6.1",
-    "build-mode": "--add-dynamic-module",
-    "ubuntu-version": "24.04",
-    "arch": "amd64"
-  },
-  {
-    "nginx-version": "1.30",
-    "ffmpeg-version": "6.1",
-    "build-mode": "--add-module",
-    "ubuntu-version": "26.04",
-    "arch": "arm64"
-  },
-  {
-    "nginx-version": "1.30",
     "ffmpeg-version": "7.1",
-    "build-mode": "--add-dynamic-module",
     "ubuntu-version": "24.04",
     "arch": "arm64"
   },
   {
-    "nginx-version": "1.31",
-    "ffmpeg-version": "7.1",
+    "nginx-version": "1.28",
     "build-mode": "--add-module",
     "ubuntu-version": "26.04",
     "arch": "amd64"
   },
   {
-    "nginx-version": "1.31",
-    "ffmpeg-version": "8.1",
+    "nginx-version": "1.28",
+    "build-mode": "--add-dynamic-module",
+    "ffmpeg-version": "distro",
+    "ubuntu-version": "26.04",
+    "arch": "arm64"
+  },
+  {
+    "nginx-version": "1.30",
     "build-mode": "--add-module",
+    "ffmpeg-version": "distro",
+    "ubuntu-version": "26.04",
+    "arch": "amd64"
+  },
+  {
+    "nginx-version": "1.30",
+    "build-mode": "--add-module",
+    "ffmpeg-version": "9.0",
+    "ubuntu-version": "26.04",
+    "arch": "arm64"
+  },
+  {
+    "nginx-version": "1.30",
+    "build-mode": "--add-dynamic-module",
+    "ffmpeg-version": "distro",
     "ubuntu-version": "24.04",
     "arch": "arm64"
   },
   {
     "nginx-version": "1.30",
-    "ffmpeg-version": "8.1",
     "build-mode": "--add-dynamic-module",
+    "ffmpeg-version": "8.1",
+    "ubuntu-version": "26.04",
+    "arch": "amd64"
+  },
+  {
+    "nginx-version": "1.31",
+    "build-mode": "--add-module",
+    "ffmpeg-version": "7.1",
+    "ubuntu-version": "26.04",
+    "arch": "amd64"
+  },
+  {
+    "nginx-version": "1.31",
+    "build-mode": "--add-module",
+    "ffmpeg-version": "8.1",
+    "ubuntu-version": "26.04",
+    "arch": "arm64"
+  },
+  {
+    "nginx-version": "1.31",
+    "build-mode": "--add-dynamic-module",
+    "ubuntu-version": "24.04",
+    "arch": "arm64"
+  },
+  {
+    "nginx-version": "1.31",
+    "build-mode": "--add-dynamic-module",
+    "ffmpeg-version": "9.0",
     "ubuntu-version": "26.04",
     "arch": "amd64"
   }

--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -1,0 +1,56 @@
+[
+  {
+    "nginx-version": "1.30",
+    "build-mode": "--add-module",
+    "ubuntu-version": "24.04",
+    "arch": "amd64"
+  },
+  {
+    "nginx-version": "1.31",
+    "build-mode": "--add-dynamic-module",
+    "ubuntu-version": "26.04",
+    "arch": "arm64"
+  },
+  {
+    "nginx-version": "1.31",
+    "ffmpeg-version": "6.1",
+    "build-mode": "--add-dynamic-module",
+    "ubuntu-version": "24.04",
+    "arch": "amd64"
+  },
+  {
+    "nginx-version": "1.30",
+    "ffmpeg-version": "6.1",
+    "build-mode": "--add-module",
+    "ubuntu-version": "26.04",
+    "arch": "arm64"
+  },
+  {
+    "nginx-version": "1.30",
+    "ffmpeg-version": "7.1",
+    "build-mode": "--add-dynamic-module",
+    "ubuntu-version": "24.04",
+    "arch": "arm64"
+  },
+  {
+    "nginx-version": "1.31",
+    "ffmpeg-version": "7.1",
+    "build-mode": "--add-module",
+    "ubuntu-version": "26.04",
+    "arch": "amd64"
+  },
+  {
+    "nginx-version": "1.31",
+    "ffmpeg-version": "8.1",
+    "build-mode": "--add-module",
+    "ubuntu-version": "24.04",
+    "arch": "arm64"
+  },
+  {
+    "nginx-version": "1.30",
+    "ffmpeg-version": "8.1",
+    "build-mode": "--add-dynamic-module",
+    "ubuntu-version": "26.04",
+    "arch": "amd64"
+  }
+]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,23 +97,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nginx-version:
-          - '1.30'
-          - '1.31'
-        ffmpeg-version:
-          - null
-          - '6.1'
-          - '7.1'
-          - '8.1'
-        build-mode:
-          - --add-module
-          - --add-dynamic-module
-        ubuntu-version:
-          - '24.04'
-          - '26.04'
-        arch:
-          - amd64
-          - arm64
+        include:
+          - { nginx-version: '1.30', build-mode: --add-module, ubuntu-version: '24.04', arch: amd64 }
+          - { nginx-version: '1.31', build-mode: --add-dynamic-module, ubuntu-version: '26.04', arch: arm64 }
+          - { nginx-version: '1.31', ffmpeg-version: '6.1', build-mode: --add-dynamic-module, ubuntu-version: '24.04', arch: amd64 }
+          - { nginx-version: '1.30', ffmpeg-version: '6.1', build-mode: --add-module, ubuntu-version: '26.04', arch: arm64 }
+          - { nginx-version: '1.30', ffmpeg-version: '7.1', build-mode: --add-dynamic-module, ubuntu-version: '24.04', arch: arm64 }
+          - { nginx-version: '1.31', ffmpeg-version: '7.1', build-mode: --add-module, ubuntu-version: '26.04', arch: amd64 }
+          - { nginx-version: '1.31', ffmpeg-version: '8.1', build-mode: --add-module, ubuntu-version: '24.04', arch: arm64 }
+          - { nginx-version: '1.30', ffmpeg-version: '8.1', build-mode: --add-dynamic-module, ubuntu-version: '26.04', arch: amd64 }
     steps:
       - run: sudo apt-get update -qq
       - run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,37 @@ permissions:
   contents: read
 
 jobs:
+  source:
+    name: Fetch ${{ matrix.package }} ${{ matrix.version }}
+    runs-on: ubuntu-26.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { package: ffmpeg, version: '6.1', url: ffmpeg.org/releases }
+          - { package: ffmpeg, version: '7.1', url: ffmpeg.org/releases }
+          - { package: ffmpeg, version: '8.1', url: ffmpeg.org/releases }
+          - { package: nginx, version: '1.30', url: nginx.org/download }
+          - { package: nginx, version: '1.31', url: nginx.org/download }
+    steps:
+      - run: sudo apt-get update -qq
+      - run: sudo apt-get install -y wget
+      - uses: actions/checkout@v7
+        with:
+          path: nginx-vod-module
+      - run: ./nginx-vod-module/scripts/fetch_latest.sh ${{ matrix.url }} ${{ matrix.package }}-${{ matrix.version }}
+      - run: tar -cf ${{ matrix.package }}-source.tar ${{ matrix.package }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.package }}-source-${{ matrix.version }}
+          path: ${{ matrix.package }}-source.tar
+          retention-days: 1
+
   ffmpeg:
     name: Build ffmpeg ${{ matrix.version }}
     runs-on: ubuntu-26.04
+    if: ${{ !cancelled() }}
+    needs: source
     strategy:
       fail-fast: false
       matrix:
@@ -27,7 +55,6 @@ jobs:
       - run: sudo apt-get update -qq
       - run: |
           sudo apt-get install -y \
-            wget \
             build-essential \
             libfdk-aac-dev \
             nasm \
@@ -35,7 +62,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           path: nginx-vod-module
-      - run: ./nginx-vod-module/scripts/fetch_latest.sh ffmpeg.org/releases ffmpeg-${{ matrix.version }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: ffmpeg-source-${{ matrix.version }}
+      - run: tar -xf ffmpeg-source.tar
       - id: ffmpeg-cache
         uses: actions/cache@v6
         with:
@@ -49,7 +79,7 @@ jobs:
       - run: tar -cf ffmpeg-build.tar -C ffmpeg-build .
       - uses: actions/upload-artifact@v7
         with:
-          name: ffmpeg-${{ matrix.version }}
+          name: ffmpeg-build-${{ matrix.version }}
           path: ffmpeg-build.tar
           retention-days: 1
 
@@ -57,7 +87,9 @@ jobs:
     name: Build for nginx ${{ matrix.nginx-version }} using ${{ matrix.build-mode }} ${{ matrix.ffmpeg-version && format('and ffmpeg {0}', matrix.ffmpeg-version) || '' }}
     runs-on: ubuntu-26.04
     if: ${{ !cancelled() }}
-    needs: ffmpeg
+    needs:
+      - source
+      - ffmpeg
     strategy:
       fail-fast: false
       matrix:
@@ -76,7 +108,6 @@ jobs:
       - run: sudo apt-get update -qq
       - run: |
           sudo apt-get install -y \
-            wget \
             build-essential \
             libfdk-aac-dev \
             libssl-dev \
@@ -88,12 +119,15 @@ jobs:
       - if: matrix.ffmpeg-version != null
         uses: actions/download-artifact@v8
         with:
-          name: ffmpeg-${{ matrix.ffmpeg-version }}
+          name: ffmpeg-build-${{ matrix.ffmpeg-version }}
       - if: matrix.ffmpeg-version != null
         run: |
           sudo tar -xf ffmpeg-build.tar -C /
           sudo ldconfig
-      - run: ./nginx-vod-module/scripts/fetch_latest.sh nginx.org/download nginx-${{ matrix.nginx-version }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: nginx-source-${{ matrix.nginx-version }}
+      - run: tar -xf nginx-source.tar
       - working-directory: nginx
         run: |
           ../nginx-vod-module/scripts/build_basic.sh \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,18 +13,25 @@ permissions:
   contents: read
 
 jobs:
+  matrix:
+    name: Resolve matrix
+    runs-on: ubuntu-latest
+    outputs:
+      source: ${{ steps.resolve.outputs.source }}
+      ffmpeg: ${{ steps.resolve.outputs.ffmpeg }}
+      build: ${{ steps.resolve.outputs.build }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: resolve
+        run: ./scripts/build_matrix.py >> "$GITHUB_OUTPUT"
+
   source:
     name: Fetch ${{ matrix.package }} ${{ matrix.version }}
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-latest
+    needs: matrix
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - { package: ffmpeg, version: '6.1', url: ffmpeg.org/releases }
-          - { package: ffmpeg, version: '7.1', url: ffmpeg.org/releases }
-          - { package: ffmpeg, version: '8.1', url: ffmpeg.org/releases }
-          - { package: nginx, version: '1.30', url: nginx.org/download }
-          - { package: nginx, version: '1.31', url: nginx.org/download }
+      matrix: ${{ fromJSON(needs.matrix.outputs.source) }}
     steps:
       - run: sudo apt-get update -qq
       - run: sudo apt-get install -y --no-install-recommends wget ca-certificates
@@ -40,21 +47,15 @@ jobs:
           retention-days: 1
 
   ffmpeg:
-    name: Build ffmpeg ${{ matrix.version }} (${{ matrix.arch }})
-    # Build on min supported version for glibc backward compatibility
-    runs-on: ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }}
+    name: Build ffmpeg ${{ matrix.ffmpeg-version }} (${{ matrix.arch }})
+    runs-on: ubuntu-${{ matrix.ubuntu-version }}${{ matrix.arch == 'arm64' && '-arm' || '' }}
     if: ${{ !cancelled() }}
-    needs: source
+    needs:
+      - matrix
+      - source
     strategy:
       fail-fast: false
-      matrix:
-        version:
-          - '6.1'
-          - '7.1'
-          - '8.1'
-        arch:
-          - amd64
-          - arm64
+      matrix: ${{ fromJSON(needs.matrix.outputs.ffmpeg) }}
     steps:
       - run: sudo apt-get update -qq
       - run: |
@@ -68,13 +69,13 @@ jobs:
           path: nginx-vod-module
       - uses: actions/download-artifact@v8
         with:
-          name: ffmpeg-source-${{ matrix.version }}
+          name: ffmpeg-source-${{ matrix.ffmpeg-version }}
       - run: tar -xf ffmpeg-source.tar
       - id: ffmpeg-cache
         uses: actions/cache@v6
         with:
           path: ffmpeg-build
-          key: ffmpeg-${{ matrix.version }}-${{ matrix.arch }}-${{ hashFiles('ffmpeg/**', 'nginx-vod-module/scripts/build_ffmpeg.sh') }}
+          key: ffmpeg-${{ matrix.ffmpeg-version }}-ubuntu-${{ matrix.ubuntu-version }}-${{ matrix.arch }}-${{ hashFiles('ffmpeg/**', 'nginx-vod-module/scripts/build_ffmpeg.sh') }}
       - if: steps.ffmpeg-cache.outputs.cache-hit != 'true'
         working-directory: ffmpeg
         run: |
@@ -83,7 +84,7 @@ jobs:
       - run: tar -cf ffmpeg-build.tar -C ffmpeg-build .
       - uses: actions/upload-artifact@v7
         with:
-          name: ffmpeg-build-${{ matrix.version }}-${{ matrix.arch }}
+          name: ffmpeg-build-${{ matrix.ffmpeg-version }}-${{ matrix.arch }}
           path: ffmpeg-build.tar
           retention-days: 1
 
@@ -92,20 +93,12 @@ jobs:
     runs-on: ubuntu-${{ matrix.ubuntu-version }}${{ matrix.arch == 'arm64' && '-arm' || '' }}
     if: ${{ !cancelled() }}
     needs:
+      - matrix
       - source
       - ffmpeg
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - { nginx-version: '1.30', build-mode: --add-module, ubuntu-version: '24.04', arch: amd64 }
-          - { nginx-version: '1.31', build-mode: --add-dynamic-module, ubuntu-version: '26.04', arch: arm64 }
-          - { nginx-version: '1.31', ffmpeg-version: '6.1', build-mode: --add-dynamic-module, ubuntu-version: '24.04', arch: amd64 }
-          - { nginx-version: '1.30', ffmpeg-version: '6.1', build-mode: --add-module, ubuntu-version: '26.04', arch: arm64 }
-          - { nginx-version: '1.30', ffmpeg-version: '7.1', build-mode: --add-dynamic-module, ubuntu-version: '24.04', arch: arm64 }
-          - { nginx-version: '1.31', ffmpeg-version: '7.1', build-mode: --add-module, ubuntu-version: '26.04', arch: amd64 }
-          - { nginx-version: '1.31', ffmpeg-version: '8.1', build-mode: --add-module, ubuntu-version: '24.04', arch: arm64 }
-          - { nginx-version: '1.30', ffmpeg-version: '8.1', build-mode: --add-dynamic-module, ubuntu-version: '26.04', arch: amd64 }
+      matrix: ${{ fromJSON(needs.matrix.outputs.build) }}
     steps:
       - run: sudo apt-get update -qq
       - run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
           - { package: nginx, version: '1.31', url: nginx.org/download }
     steps:
       - run: sudo apt-get update -qq
-      - run: sudo apt-get install -y wget
+      - run: sudo apt-get install -y --no-install-recommends wget ca-certificates
       - uses: actions/checkout@v7
         with:
           path: nginx-vod-module
@@ -54,7 +54,7 @@ jobs:
     steps:
       - run: sudo apt-get update -qq
       - run: |
-          sudo apt-get install -y \
+          sudo apt-get install -y --no-install-recommends \
             build-essential \
             libfdk-aac-dev \
             nasm \
@@ -107,12 +107,13 @@ jobs:
     steps:
       - run: sudo apt-get update -qq
       - run: |
-          sudo apt-get install -y \
+          sudo apt-get install -y --no-install-recommends \
             build-essential \
             libfdk-aac-dev \
             libssl-dev \
             libxml2-dev \
-            libpcre2-dev
+            libpcre2-dev \
+            zlib1g-dev
       - uses: actions/checkout@v7
         with:
           path: nginx-vod-module

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,11 +112,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           path: nginx-vod-module
-      - if: matrix.ffmpeg-version != null
+      - if: matrix.ffmpeg-version == 'distro'
+        run: |
+          sudo apt-get install -y --no-install-recommends \
+            libavcodec-dev \
+            libavfilter-dev \
+            libswscale-dev
+      - if: matrix.ffmpeg-version && matrix.ffmpeg-version != 'distro'
         uses: actions/download-artifact@v8
         with:
           name: ffmpeg-build-${{ matrix.ffmpeg-version }}-${{ matrix.arch }}
-      - if: matrix.ffmpeg-version != null
+      - if: matrix.ffmpeg-version && matrix.ffmpeg-version != 'distro'
         run: |
           sudo tar -xf ffmpeg-build.tar -C /
           sudo ldconfig

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,6 +136,7 @@ jobs:
             ${{ matrix.build-mode }}=../nginx-vod-module \
             --with-cc-opt='-O3 ${{ matrix.arch == 'amd64' && '-mpopcnt' || '' }}'
           sudo make install
+          sudo mkdir -p /var/spool/nginx
       - run: /opt/nginx/sbin/nginx -V
       - if: matrix.ffmpeg-version
         working-directory: nginx
@@ -143,6 +144,8 @@ jobs:
           grep NGX_HAVE_LIB_AV_CODEC objs/ngx_auto_config.h
           grep NGX_HAVE_LIB_AV_FILTER objs/ngx_auto_config.h
           grep NGX_HAVE_LIB_SW_SCALE objs/ngx_auto_config.h
+      - if: matrix.build-mode == '--add-dynamic-module'
+        run: sudo /opt/nginx/sbin/nginx -t -g 'load_module modules/ngx_http_vod_module.so;'
       - working-directory: nginx-vod-module/test
         env:
           NGINX_SOURCE_DIR: ../../nginx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,6 +137,12 @@ jobs:
             --with-cc-opt='-O3 ${{ matrix.arch == 'amd64' && '-mpopcnt' || '' }}'
           sudo make install
       - run: /opt/nginx/sbin/nginx -V
+      - if: matrix.ffmpeg-version
+        working-directory: nginx
+        run: |
+          grep NGX_HAVE_LIB_AV_CODEC objs/ngx_auto_config.h
+          grep NGX_HAVE_LIB_AV_FILTER objs/ngx_auto_config.h
+          grep NGX_HAVE_LIB_SW_SCALE objs/ngx_auto_config.h
       - working-directory: nginx-vod-module/test
         env:
           NGINX_SOURCE_DIR: ../../nginx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,8 +40,9 @@ jobs:
           retention-days: 1
 
   ffmpeg:
-    name: Build ffmpeg ${{ matrix.version }}
-    runs-on: ubuntu-26.04
+    name: Build ffmpeg ${{ matrix.version }} (${{ matrix.arch }})
+    # Build on min supported version for glibc backward compatibility
+    runs-on: ubuntu-24.04${{ matrix.arch == 'arm64' && '-arm' || '' }}
     if: ${{ !cancelled() }}
     needs: source
     strategy:
@@ -51,6 +52,9 @@ jobs:
           - '6.1'
           - '7.1'
           - '8.1'
+        arch:
+          - amd64
+          - arm64
     steps:
       - run: sudo apt-get update -qq
       - run: |
@@ -70,7 +74,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ffmpeg-build
-          key: ffmpeg-${{ matrix.version }}-${{ hashFiles('ffmpeg/**', 'nginx-vod-module/scripts/build_ffmpeg.sh') }}
+          key: ffmpeg-${{ matrix.version }}-${{ matrix.arch }}-${{ hashFiles('ffmpeg/**', 'nginx-vod-module/scripts/build_ffmpeg.sh') }}
       - if: steps.ffmpeg-cache.outputs.cache-hit != 'true'
         working-directory: ffmpeg
         run: |
@@ -79,13 +83,13 @@ jobs:
       - run: tar -cf ffmpeg-build.tar -C ffmpeg-build .
       - uses: actions/upload-artifact@v7
         with:
-          name: ffmpeg-build-${{ matrix.version }}
+          name: ffmpeg-build-${{ matrix.version }}-${{ matrix.arch }}
           path: ffmpeg-build.tar
           retention-days: 1
 
   build:
-    name: Build for nginx ${{ matrix.nginx-version }} using ${{ matrix.build-mode }} ${{ matrix.ffmpeg-version && format('and ffmpeg {0}', matrix.ffmpeg-version) || '' }}
-    runs-on: ubuntu-26.04
+    name: Build for nginx ${{ matrix.nginx-version }}${{ matrix.ffmpeg-version && format(' with ffmpeg {0}', matrix.ffmpeg-version) || '' }} (${{ matrix.build-mode }}, ubuntu-${{ matrix.ubuntu-version }}, ${{ matrix.arch }})
+    runs-on: ubuntu-${{ matrix.ubuntu-version }}${{ matrix.arch == 'arm64' && '-arm' || '' }}
     if: ${{ !cancelled() }}
     needs:
       - source
@@ -104,6 +108,12 @@ jobs:
         build-mode:
           - --add-module
           - --add-dynamic-module
+        ubuntu-version:
+          - '24.04'
+          - '26.04'
+        arch:
+          - amd64
+          - arm64
     steps:
       - run: sudo apt-get update -qq
       - run: |
@@ -120,7 +130,7 @@ jobs:
       - if: matrix.ffmpeg-version != null
         uses: actions/download-artifact@v8
         with:
-          name: ffmpeg-build-${{ matrix.ffmpeg-version }}
+          name: ffmpeg-build-${{ matrix.ffmpeg-version }}-${{ matrix.arch }}
       - if: matrix.ffmpeg-version != null
         run: |
           sudo tar -xf ffmpeg-build.tar -C /
@@ -133,7 +143,7 @@ jobs:
         run: |
           ../nginx-vod-module/scripts/build_basic.sh \
             ${{ matrix.build-mode }}=../nginx-vod-module \
-            --with-cc-opt='-O3 -mpopcnt'
+            --with-cc-opt='-O3 ${{ matrix.arch == 'amd64' && '-mpopcnt' || '' }}'
           sudo make install
       - run: /opt/nginx/sbin/nginx -V
       - working-directory: nginx-vod-module/test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,51 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build for NGINX ${{ matrix.nginx-version }} using ${{ matrix.build-mode }} ${{ matrix.ffmpeg-version && format('and FFmpeg {0}', matrix.ffmpeg-version) || '' }}
+  ffmpeg:
+    name: Build ffmpeg ${{ matrix.version }}
     runs-on: ubuntu-26.04
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '6.1'
+          - '7.1'
+          - '8.1'
+    steps:
+      - run: sudo apt-get update -qq
+      - run: |
+          sudo apt-get install -y \
+            wget \
+            build-essential \
+            libfdk-aac-dev \
+            nasm \
+            pkg-config
+      - uses: actions/checkout@v7
+        with:
+          path: nginx-vod-module
+      - run: ./nginx-vod-module/scripts/fetch_latest.sh ffmpeg.org/releases ffmpeg-${{ matrix.version }}
+      - id: ffmpeg-cache
+        uses: actions/cache@v6
+        with:
+          path: ffmpeg-build
+          key: ffmpeg-${{ matrix.version }}-${{ hashFiles('ffmpeg/**', 'nginx-vod-module/scripts/build_ffmpeg.sh') }}
+      - if: steps.ffmpeg-cache.outputs.cache-hit != 'true'
+        working-directory: ffmpeg
+        run: |
+          ../nginx-vod-module/scripts/build_ffmpeg.sh --prefix=/usr/local
+          make install DESTDIR=$GITHUB_WORKSPACE/ffmpeg-build
+      - run: tar -cf ffmpeg-build.tar -C ffmpeg-build .
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ffmpeg-${{ matrix.version }}
+          path: ffmpeg-build.tar
+          retention-days: 1
+
+  build:
+    name: Build for nginx ${{ matrix.nginx-version }} using ${{ matrix.build-mode }} ${{ matrix.ffmpeg-version && format('and ffmpeg {0}', matrix.ffmpeg-version) || '' }}
+    runs-on: ubuntu-26.04
+    if: ${{ !cancelled() }}
+    needs: ffmpeg
     strategy:
       fail-fast: false
       matrix:
@@ -39,28 +81,17 @@ jobs:
             libfdk-aac-dev \
             libssl-dev \
             libxml2-dev \
-            libpcre2-dev \
-            nasm \
-            pkg-config
+            libpcre2-dev
       - uses: actions/checkout@v7
         with:
           path: nginx-vod-module
       - if: matrix.ffmpeg-version != null
-        run: ./nginx-vod-module/scripts/fetch_latest.sh ffmpeg.org/releases ffmpeg-${{ matrix.ffmpeg-version }}
-      - if: matrix.ffmpeg-version != null
-        id: ffmpeg-cache
-        uses: actions/cache@v6
+        uses: actions/download-artifact@v8
         with:
-          path: ffmpeg-cache
-          key: ${{ hashFiles('ffmpeg/**', 'nginx-vod-module/scripts/build_ffmpeg.sh') }}
-      - if: matrix.ffmpeg-version != null && steps.ffmpeg-cache.outputs.cache-hit != 'true'
-        working-directory: ffmpeg
-        run: |
-          ../nginx-vod-module/scripts/build_ffmpeg.sh --prefix=/usr/local
-          make install DESTDIR=$GITHUB_WORKSPACE/ffmpeg-cache
+          name: ffmpeg-${{ matrix.ffmpeg-version }}
       - if: matrix.ffmpeg-version != null
         run: |
-          sudo cp -aT ffmpeg-cache /
+          sudo tar -xf ffmpeg-build.tar -C /
           sudo ldconfig
       - run: ./nginx-vod-module/scripts/fetch_latest.sh nginx.org/download nginx-${{ matrix.nginx-version }}
       - working-directory: nginx

--- a/scripts/build_matrix.py
+++ b/scripts/build_matrix.py
@@ -14,7 +14,7 @@ matrix = json.loads(matrix_path.read_text())
 installs = {
 	(row['ffmpeg-version'], row['arch'])
 	for row in matrix
-	if 'ffmpeg-version' in row
+	if row.get('ffmpeg-version') not in (None, 'distro')
 }
 
 # Min supported version for glibc backward compatibility

--- a/scripts/build_matrix.py
+++ b/scripts/build_matrix.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import json
+from pathlib import Path
+
+PACKAGES = {
+	'ffmpeg': 'ffmpeg.org/releases',
+	'nginx': 'nginx.org/download',
+}
+
+matrix_path = Path(__file__).parents[1] / '.github/matrix.json'
+matrix = json.loads(matrix_path.read_text())
+
+installs = {
+	(row['ffmpeg-version'], row['arch'])
+	for row in matrix
+	if 'ffmpeg-version' in row
+}
+
+# Min supported version for glibc backward compatibility
+min_version = min(row['ubuntu-version'] for row in matrix)
+
+ffmpeg = [
+	{'ffmpeg-version': version, 'ubuntu-version': min_version, 'arch': arch}
+	for version, arch in sorted(installs)
+]
+
+tarballs = {('nginx', row['nginx-version']) for row in matrix}
+tarballs |= {('ffmpeg', row['ffmpeg-version']) for row in ffmpeg}
+
+source = [
+	{'package': package, 'version': version, 'url': PACKAGES[package]}
+	for package, version in sorted(tarballs)
+]
+
+for name, rows in ('source', source), ('ffmpeg', ffmpeg), ('build', matrix):
+	print(f'{name}={json.dumps({'include': rows})}')


### PR DESCRIPTION
Improves workflow speed and reliability by deduping source fetching and FFmpeg builds. Expands coverage to include the last two Ubuntu LTS releases (`amd64`/`arm64`), NGINX `1.24` (Ubuntu 24.04) and `1.28` (Ubuntu 26.04), and FFmpeg `6.1` (Ubuntu 24.04), `8.0` (Ubuntu 26.04), and `9.0`.